### PR TITLE
fix: use consistent positional arg coloring in command list

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ module.exports = {
   // style normal help text
   group: s => c().white(s),
   flags: (s, type) => {
-    if (type.datatype === 'command') return c().magenta(s)
+    if (type.datatype === 'command') {
+      s = s.split(' ')
+      return c().magenta(s[0]) + (s[1] ? ' ' + c().green(s.slice(1).join(' ')) : '')
+    }
     return s[0] === '-' ? c().cyan(s) : c().green(s)
   },
   hints: s => c().dim(s),

--- a/index.js
+++ b/index.js
@@ -1,29 +1,35 @@
-const chalk = require('chalk')
+let _c
+function c () {
+  if (!_c) _c = require('chalk')
+  return _c
+}
 
 module.exports = {
   // style usage components
   usagePrefix: s => {
-    return chalk.white(s.slice(0, 6)) + ' ' + chalk.magenta(s.slice(7))
+    return c().white(s.slice(0, 6)) + ' ' + c().magenta(s.slice(7))
   },
-  usageCommandPlaceholder: s => chalk.magenta(s),
-  usagePositionals: s => chalk.green(s),
-  usageArgsPlaceholder: s => chalk.green(s),
-  usageOptionsPlaceholder: s => chalk.cyan(s),
+  usageCommandPlaceholder: s => c().magenta(s),
+  usagePositionals: s => c().green(s),
+  usageArgsPlaceholder: s => c().green(s),
+  usageOptionsPlaceholder: s => c().cyan(s),
   // style normal help text
-  group: s => chalk.white(s),
+  group: s => c().white(s),
   flags: (s, type) => {
-    if (type.datatype === 'command') return chalk.magenta(s)
-    return s[0] === '-' ? chalk.cyan(s) : chalk.green(s)
+    if (type.datatype === 'command') return c().magenta(s)
+    return s[0] === '-' ? c().cyan(s) : c().green(s)
   },
-  hints: s => chalk.dim(s),
-  example: s => chalk.yellow(s[0]) + s.slice(1),
+  hints: s => c().dim(s),
+  example: s => c().yellow(s[0]) + s.slice(1),
   // use different style when a type is invalid
-  groupError: s => chalk.red(s),
-  flagsError: s => chalk.red(s),
-  descError: s => chalk.yellow(s),
-  hintsError: s => chalk.red(s),
+  groupError: s => c().red(s),
+  flagsError: s => c().red(s),
+  descError: s => c().yellow(s),
+  hintsError: s => c().red(s),
   // style error messages
-  messages: s => chalk.red(s),
+  messages: s => c().red(s),
   // expose chalk
-  chalk
+  get chalk () {
+    return c()
+  }
 }

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ const test = require('tap').test
 const basicStyle = require('./')
 const chalk = basicStyle.chalk
 const sywac = require('sywac')
+  .command('abc', { desc: 'Look ma no args' })
   .command('x <y> [z]', {
     desc: 'Some command',
     paramsDesc: [
@@ -33,7 +34,8 @@ test('works for standard help text', t => {
       chalk`{white Usage:} {magenta test} {magenta <command>} {green <args>} {cyan [options]}`,
       '',
       chalk.white('Commands:'),
-      chalk`  {magenta x <y> [z]}  Some command`,
+      chalk`  {magenta abc}        Look ma no args`,
+      chalk`  {magenta x} {green <y> [z]}  Some command`,
       '',
       chalk.white('Options:'),
       chalk`  {cyan -h, --help}  Show help                 {dim [commands: help] [boolean]}`,


### PR DESCRIPTION
Before, the style was blindly using magenta for command flags in the command list, which included any positional args defined for the command. This PR fixes that by coloring the command magenta but coloring the positional args green, for consistency with usage and the arguments list.