### PR TITLE
chore: bump Node, dev deps, travis config, badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - 'node'
+  - '12'
   - '10'
-  - '8'
 after_success: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
 language: node_js
+os: linux
+dist: bionic
 node_js:
   - 'node'
   - '12'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Build Status](https://travis-ci.com/sywac/sywac-style-basic.svg?branch=master)](https://travis-ci.com/sywac/sywac-style-basic)
 [![Coverage Status](https://coveralls.io/repos/github/sywac/sywac-style-basic/badge.svg?branch=master)](https://coveralls.io/github/sywac/sywac-style-basic?branch=master)
-[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![Greenkeeper badge](https://badges.greenkeeper.io/sywac/sywac-style-basic.svg)](https://greenkeeper.io/)
+[![JavaScript Style Guide](https://badgen.net/badge/code%20style/standard/green)](https://standardjs.com)
+![Dependabot Badge](https://badgen.net/dependabot/sywac/sywac-style-basic?icon=dependabot)
 
 ![Default Help Screenshot](screenshot1.png)
 ![Error Message Screenshot](screenshot2.png)
@@ -37,7 +37,7 @@ See code snippet above for usage.
 
 ## Related
 
-- [sywac](http://sywac.io/) - The CLI library you should be using with this package
+- [sywac](https://sywac.io/) - The CLI library you should be using with this package
 - [chalk](https://github.com/chalk/chalk) - The library used by this package to make pretty colors
 - [@tryghost/pretty-cli](https://www.npmjs.com/package/@tryghost/pretty-cli) - Wraps/exposes a sywac instance preconfigured with its own opinionated styling
 - [cies](https://github.com/nexdrew/cies) - Example of a CLI that uses this package

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This will add style hooks to make your CLI help text colorful/pretty.
 
 Note that this package DOES NOT wrap/include/come with sywac - you should have sywac as a sibling dependency.
 
-Visit http://sywac.io/docs/sync-config.html#style for detailed documentation.
+Visit https://sywac.io/docs/sync-config.html#style for detailed documentation.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "bugs": {
     "url": "https://github.com/sywac/sywac-style-basic/issues"
   },
-  "homepage": "http://sywac.io/docs/sync-config.html#style",
+  "homepage": "https://sywac.io/docs/sync-config.html#style",
   "dependencies": {
     "chalk": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "chalk": "^4.0.0"
   },
   "devDependencies": {
-    "coveralls": "^3.0.6",
-    "standard": "^14.0.0",
+    "coveralls": "^3.1.0",
+    "standard": "^14.3.4",
     "standard-version": "^8.0.0",
-    "sywac": "^1.2.2",
-    "tap": "^14.6.1"
+    "sywac": "^1.3.0",
+    "tap": "^14.10.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "files": [
     "index.js"
   ],
+  "engines": {
+    "node": ">=10"
+  },
   "scripts": {
     "pretest": "standard",
     "test": "tap --cov test.js",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node 8, now requires Node 10+